### PR TITLE
Better action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,11 @@ branding:
 inputs:
   token:
     description: "Github Token"
-    required: true
+    required: false
+    default: ${{ github.token }}
   version:  # id of input
     description: 'Version of binaryen to install'
-    required: true
+    required: false
     default: 'latest'
 runs:
   using: 'node16'


### PR DESCRIPTION
- token
  - You don't need to let users set up the GitHub token.
- version
  - It's not required because a valid value is given by default.